### PR TITLE
Fixed links in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@ This plugin enables folding by section headings in markdown documents.
 
 ## Installation
 
-I recommend installing `markdown-folding` using [pathogen][] or [Vundle][]. Your `vimrc` file must contain these lines at the very least:
+I recommend installing `markdown-folding` using [Pathogen](https://github.com/tpope/vim-pathogen) or [Vundle](https://github.com/gmarik/vundle). Your `vimrc` file must contain these lines at the very least:
 
     set nocompatible
     if has("autocmd")
       filetype plugin indent on
     endif
 
-The `markdown-folding` plugin provides nothing more than a `foldexpr` for markdown files. If you want syntax highlighting and other niceties, then go and get tpope's [vim-markdown][] plugin.
+The `markdown-folding` plugin provides nothing more than a `foldexpr` for markdown files. If you want syntax highlighting and other niceties, then go and get tpope's [vim-markdown](https://github.com/tpope/vim-markdown) plugin.


### PR DESCRIPTION
I found that the links to Pathogen, Vundle and vim-markdown were not
correctly linked, so I fixed it for you. :)
