### PR TITLE
FIX: Correct parsing for Setext-style header underline

### DIFF
--- a/after/ftplugin/markdown/folding.vim
+++ b/after/ftplugin/markdown/folding.vim
@@ -30,9 +30,9 @@ function! HeadingDepth(lnum)
   else
     if thisline != ''
       let nextline = getline(a:lnum + 1)
-      if nextline =~ '^==='
+      if nextline =~ '^=\+\s*$'
         let level = 1
-      elseif nextline =~ '^---'
+      elseif nextline =~ '^-\+\s*$'
         let level = 2
       endif
     endif


### PR DESCRIPTION
According to John Gruber's spec and the Stack Overflow parser, the underlining of H1 / H2 using equal signs / dashes requires 1+ instances (not 3+), and the line must not contain anything else.
