### PR TITLE
ENH: Add foldlevel=7 for horizontal rules.

### DIFF
--- a/after/ftplugin/markdown/folding.vim
+++ b/after/ftplugin/markdown/folding.vim
@@ -27,6 +27,8 @@ function! HeadingDepth(lnum)
   let hashCount = len(matchstr(thisline, '^#\{1,6}'))
   if hashCount > 0
     let level = hashCount
+  elseif thisline =~ '^\([-_*]\) *\1 *\1\%(\1\| \)*$' && (thisline !~ '^-\{3,} *$' || getline(a:lnum - 1) =~ '^\s*$')
+    let level = 7
   else
     if thisline != ''
       let nextline = getline(a:lnum + 1)


### PR DESCRIPTION
According to John Gruber's spec and the Stack Overflow implementation, horizontal rules are defined by three or more hyphens, asterisks, or underscores (optionally separated by spaces) on a line.

Since horizontal rules are a (weak kind of) structuring mechanism, include them as foldlevel 7, after all possible headings.
