### PR TITLE
Add option to disable overriding foldtext

### DIFF
--- a/after/ftplugin/markdown/folding.vim
+++ b/after/ftplugin/markdown/folding.vim
@@ -98,8 +98,16 @@ if !exists('g:markdown_fold_style')
   let g:markdown_fold_style = 'stacked'
 endif
 
+if !exists('g:markdown_fold_override_foldtext')
+  let g:markdown_fold_override_foldtext = 1
+endif
+
 setlocal foldmethod=expr
-let &l:foldtext = s:SID() . 'FoldText()'
+
+if g:markdown_fold_override_foldtext
+  let &l:foldtext = s:SID() . 'FoldText()'
+endif
+
 let &l:foldexpr =
   \ g:markdown_fold_style ==# 'nested'
   \ ? 'NestedMarkdownFolds()'

--- a/doc/markdown-folding.txt
+++ b/doc/markdown-folding.txt
@@ -73,4 +73,9 @@ The fold style is scoped to each window, which means it's possible to use the
 stacked folding style in one split window, and the nested folding style in
 another.
 
+                                           *g:markdown_fold_override_foldtext*
+If set to 0, the fold text will not be overriden:>
+    let g:markdown_fold_override_foldtext = 0
+<
+
  vim:tw=78:ts=8:ft=help:norl:


### PR DESCRIPTION
Personally, I don't like if plugins try to know what I want to see. This change adds a `g:markdown_fold_override_foldtext` option to disable overriding the foldtext. Setting the variable to 0 will stop the plugin from setting the custom foldtext function.
