### PR TITLE
Align title and linecount

### DIFF
--- a/after/ftplugin/markdown/folding.vim
+++ b/after/ftplugin/markdown/folding.vim
@@ -77,10 +77,12 @@ endfunction
 function! s:FoldText()
   let level = HeadingDepth(v:foldstart)
   let indent = repeat('#', level)
+  let spaces_1 = repeat(' ', 5 - level)
   let title = substitute(getline(v:foldstart), '^#\+\s*', '', '')
+  let spaces_2 = repeat(' ', 30 - len(title))
   let foldsize = (v:foldend - v:foldstart)
   let linecount = '['.foldsize.' line'.(foldsize>1?'s':'').']'
-  return indent.' '.title.' '.linecount
+  return indent.spaces_1.title.spaces_2.linecount
 endfunction
 
 " API {{{1


### PR DESCRIPTION
This commit left aligns both the title and line count section of the fold header. It only works with titles with a length of 30 chars or less, but this seems sufficient to me.

In the attached screen shot the new behaviour is in the bottom window.

![2014-05-31-221546_517x304_scrot](https://cloud.githubusercontent.com/assets/287050/3140143/10631f0e-e909-11e3-9c7f-bddb8bf8b566.png)
