### PR TITLE
[WIP] fold on fenced code blocks

### DIFF
--- a/after/ftplugin/markdown/folding.vim
+++ b/after/ftplugin/markdown/folding.vim
@@ -70,7 +70,7 @@ endfunction
 function! LineIsFenced(lnum)
   if exists("b:current_syntax") && b:current_syntax ==# 'markdown'
     " It's cheap to check if the current line has 'markdownCode' syntax group
-    return s:HasSyntaxGroup(a:lnum, 'markdownCode')
+    return HasSyntaxGroup(a:lnum, '\vmarkdown(Code|Highlight)')
   else
     " Using searchpairpos() is expensive, so only do it if syntax highlighting
     " is not enabled
@@ -78,11 +78,11 @@ function! LineIsFenced(lnum)
   endif
 endfunction
 
-function! s:HasSyntaxGroup(lnum, targetGroup)
+function! HasSyntaxGroup(lnum, targetGroup)
   let syntaxGroup = map(synstack(a:lnum, 1), 'synIDattr(v:val, "name")')
   for value in syntaxGroup
-    if value =~ '\vmarkdown(Code|Highlight)'
-      return 1
+    if value =~ a:targetGroup
+        return 1
     endif
   endfor
 endfunction

--- a/after/ftplugin/markdown/folding.vim
+++ b/after/ftplugin/markdown/folding.vim
@@ -1,5 +1,13 @@
 " Fold expressions {{{1
 function! StackedMarkdownFolds()
+  let thisline = getline(v:lnum)
+  let prevline = getline(v:lnum - 1)
+  let nextline = getline(v:lnum + 1)
+  if thisline =~ '^```.*$' && prevline =~ '^\s*$'  " start of a fenced block
+    return ">2"
+  elseif thisline =~ '^```$' && nextline =~ '^\s*$'  " end of a fenced block
+    return "<2"
+  endif
   if HeadingDepth(v:lnum) > 0
     return ">1"
   else
@@ -8,6 +16,14 @@ function! StackedMarkdownFolds()
 endfunction
 
 function! NestedMarkdownFolds()
+  let thisline = getline(v:lnum)
+  let prevline = getline(v:lnum - 1)
+  let nextline = getline(v:lnum + 1)
+  if thisline =~ '^```.*$' && prevline =~ '^\s*$'  " start of a fenced block
+    return "a1"
+  elseif thisline =~ '^```$' && nextline =~ '^\s*$'  " end of a fenced block
+    return "s1"
+  endif
   let depth = HeadingDepth(v:lnum)
   if depth > 0
     return ">".depth

--- a/after/ftplugin/markdown/folding.vim
+++ b/after/ftplugin/markdown/folding.vim
@@ -23,6 +23,13 @@ endfunction
 
 function! HeadingDepth(lnum)
   let level=0
+
+  " heading must be preceded by a blank line unless
+  " it is at start of file
+  if a:lnum != 1 && getline(a:lnum - 1) !~ '^\s*$'
+    return level
+  endif
+
   let thisline = getline(a:lnum)
   let hashCount = len(matchstr(thisline, '^#\{1,6}'))
   if hashCount > 0


### PR DESCRIPTION
You probably don't want to merge this as-is but I thought I'd let you see what I'm doing.

I wanted to be able to fold fenced code blocks and that is what this allows you to do.

[vim-pandoc](https://github.com/vim-pandoc/vim-pandoc) lets you fold fenced code blocks but it does so using `foldmethod=syntax` which can get pretty slow.

Also I've required headers to be preceded by a blank line (as per the pandoc spec, but not the original markdown spec).
