### PR TITLE
Tab-indent the foldtext depending on header level

### DIFF
--- a/after/ftplugin/markdown/folding.vim
+++ b/after/ftplugin/markdown/folding.vim
@@ -76,11 +76,12 @@ endfunction
 
 function! s:FoldText()
   let level = HeadingDepth(v:foldstart)
+  let tabindent = repeat("\t\t", level - 1)
   let indent = repeat('#', level)
   let title = substitute(getline(v:foldstart), '^#\+\s*', '', '')
   let foldsize = (v:foldend - v:foldstart)
   let linecount = '['.foldsize.' line'.(foldsize>1?'s':'').']'
-  return indent.' '.title.' '.linecount
+  return tabindent.' '.indent.' '.title.' '.linecount
 endfunction
 
 " API {{{1


### PR DESCRIPTION
adds tabindents to the foldtext for header level 2 and above. This makes it easier to distinguish different levels. Instead of this:
```
# H1
## H2
### H3 
```
It looks something likes this
```
# H1
  ## H2
    ### H3
```