### PR TITLE
Fix bug that treat ^##abc as title.  One or more spaces should be required

### DIFF
--- a/after/ftplugin/markdown/folding.vim
+++ b/after/ftplugin/markdown/folding.vim
@@ -24,9 +24,9 @@ endfunction
 function! HeadingDepth(lnum)
   let level=0
   let thisline = getline(a:lnum)
-  let hashCount = len(matchstr(thisline, '^#\{1,6}'))
-  if hashCount > 0
-    let level = hashCount
+  let hashCount = len(matchstr(thisline, '^#\{1,6}\s'))
+  if hashCount > 1
+    let level = hashCount - 1
   else
     if thisline != ''
       let nextline = getline(a:lnum + 1)
@@ -77,7 +77,7 @@ endfunction
 function! s:FoldText()
   let level = HeadingDepth(v:foldstart)
   let indent = repeat('#', level)
-  let title = substitute(getline(v:foldstart), '^#\+\s*', '', '')
+  let title = substitute(getline(v:foldstart), '^#\+\s\+', '', '')
   let foldsize = (v:foldend - v:foldstart)
   let linecount = '['.foldsize.' line'.(foldsize>1?'s':'').']'
   return indent.' '.title.' '.linecount


### PR DESCRIPTION
To use # as tag mark, only lines started with one or more # and one or more whitespace is title.

```
# title
#tags#

content
```