### PR TITLE
Feat/fold html comments

### DIFF
--- a/after/ftplugin/markdown/folding.vim
+++ b/after/ftplugin/markdown/folding.vim
@@ -8,7 +8,13 @@ function! StackedMarkdownFolds()
   elseif thisline =~ '^```$' && nextline =~ '^\s*$'  " end of a fenced block
     return "<2"
   endif
-  
+
+  if thisline =~ '^<!--.*$' && prevline =~ '^\s*$'  " start of an HTML commented block
+    return ">2"
+  elseif thisline =~ '^-->$' && nextline =~ '^\s*$'  " end of an HTML commented block
+    return "<2"
+  endif
+
   if HeadingDepth(v:lnum) > 0
     return ">1"
   else
@@ -23,6 +29,12 @@ function! NestedMarkdownFolds()
   if thisline =~ '^```.*$' && prevline =~ '^\s*$'  " start of a fenced block
     return "a1"
   elseif thisline =~ '^```$' && nextline =~ '^\s*$'  " end of a fenced block
+    return "s1"
+  endif
+
+  if thisline =~ '^<!--.*$' && prevline =~ '^\s*$'  " start of an HTML commented block
+    return "a1"
+  elseif thisline =~ '^-->$' && nextline =~ '^\s*$'  " end of an HTML commented block
     return "s1"
   endif
 

--- a/after/ftplugin/markdown/folding.vim
+++ b/after/ftplugin/markdown/folding.vim
@@ -3,15 +3,9 @@ function! StackedMarkdownFolds()
   let thisline = getline(v:lnum)
   let prevline = getline(v:lnum - 1)
   let nextline = getline(v:lnum + 1)
-  if thisline =~ '^```.*$' && prevline =~ '^\s*$'  " start of a fenced block
+  if thisline =~ '^\%(```\|<!--\).*$' && prevline =~ '^\s*$'  " start of a fenced block or HTML commented block
     return ">2"
-  elseif thisline =~ '^```$' && nextline =~ '^\s*$'  " end of a fenced block
-    return "<2"
-  endif
-
-  if thisline =~ '^<!--.*$' && prevline =~ '^\s*$'  " start of an HTML commented block
-    return ">2"
-  elseif thisline =~ '^-->$' && nextline =~ '^\s*$'  " end of an HTML commented block
+  elseif thisline =~ '^\%(```\|-->\)$' && nextline =~ '^\s*$'  " end of a fenced block or HTML commented block
     return "<2"
   endif
 
@@ -26,15 +20,9 @@ function! NestedMarkdownFolds()
   let thisline = getline(v:lnum)
   let prevline = getline(v:lnum - 1)
   let nextline = getline(v:lnum + 1)
-  if thisline =~ '^```.*$' && prevline =~ '^\s*$'  " start of a fenced block
+  if thisline =~ '^\%(```\|<!--\).*$' && prevline =~ '^\s*$'  " start of a fenced block or HTML commented block
     return "a1"
-  elseif thisline =~ '^```$' && nextline =~ '^\s*$'  " end of a fenced block
-    return "s1"
-  endif
-
-  if thisline =~ '^<!--.*$' && prevline =~ '^\s*$'  " start of an HTML commented block
-    return "a1"
-  elseif thisline =~ '^-->$' && nextline =~ '^\s*$'  " end of an HTML commented block
+  elseif thisline =~ '^\%(```\|-->\)$' && nextline =~ '^\s*$'  " end of a fenced block or HTML commented block
     return "s1"
   endif
 


### PR DESCRIPTION
I've found it useful to fold commented sections of text.

There are two commits: the first implements the changes by duplicating the code block treatment, the second uses a pair of regexes which match both code blocks and html comments. It seems to work (so far) in nested mode, though I haven't tried stacked mode. I don't know how nested code blocks within html comments will work (or vice versa, I suppose).

I hope you find it useful, too!