### PR TITLE
Fixed issue with s:SID in Vim 8.2

### DIFF
--- a/after/ftplugin/markdown/folding.vim
+++ b/after/ftplugin/markdown/folding.vim
@@ -36,7 +36,7 @@ endfunction
 
 " Helpers {{{1
 function! s:SID()
-  return matchstr(expand('<sfile>'), '<SNR>\d\+_')
+  return matchstr(expand('<sfile>'), '\zs<SNR>\d\+_\zeSID$')
 endfunction
 
 function! HeadingDepth(lnum)


### PR DESCRIPTION
The pattern used to match against `<sfile>` to generate an SID doesn't work with the new `<sfile>` format returned by Vim 8.2. This patch contains a backward compatible fix.